### PR TITLE
Adding support for Base64url

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Returns a string containing the decoded UUID from `str`.
 | `'base58'` | _Custom_ | Bitcoin Base 58 |
 | `'base62'` | 0-9, A-Z, a-z | Base 62 |
 | `'base64'` | 0-9, A-Z, a-z, +, / | Base 64 |
+| `'base64url'` | 0-9, A-Z, a-z, -, _ | Base 64 URL encoding (RFC 4648) |
 
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const bigInt = require('big-integer');
 
 const knownBases = {
+  base64url: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_',
   base64: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+/',
   base62: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
   base58: '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz', // Bitcoin base58
@@ -13,6 +14,8 @@ const knownBases = {
 
 
 const caseSensitiveBases = {
+  base64url: true,
+  base64: true,
   base62: true,
   base58: true,
   base36: false,

--- a/test/lib/data.json
+++ b/test/lib/data.json
@@ -1,5 +1,5 @@
 {
-  "encodings" : ["base2", "base10", "base16", "base32", "base36", "base58", "base62", "base64"],
+  "encodings" : ["base2", "base10", "base16", "base32", "base36", "base58", "base62", "base64", "base64url"],
 
   "uuids" : [
     "00000000-0000-0000-0000-000000000000",


### PR DESCRIPTION
This adds support for base64url, which is identical to Base64 except it uses more url-friendly characters for the last two. Base64's `+` and `/` are replaced with `-` and `_`, respectively.